### PR TITLE
Fail fast page refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ set(APP_SOURCES
     src/ui/ui_text.c
     src/ui/ui_text_input.c
     src/ui/ui_window.c
+    src/util/fail_fast.c
     src/util/string_util.c)
 
 # Create your game executable target as usual

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ In short: resize updates page-level geometry immediately, and container-based ch
 
 - Element constructors (`ui_button_create`, `ui_pane_create`, etc.) allocate on the heap and return ownership to caller.
 - After `ui_runtime_add` succeeds, ownership transfers to `ui_runtime`.
-- `todo_page_create` registers page elements in `ui_runtime`; on any partial failure it rolls back and destroys already-registered page elements before returning `NULL`.
+- Sample page constructors (`todo_page_create`, `corners_page_create`, `showcase_page_create`) now follow a fail-fast policy for unrecoverable internal failures (allocation/creation/registration): they log a critical error and abort instead of returning a recoverable error to callers.
 - `todo_page_destroy` removes and destroys elements that were registered by the page, then frees page-owned task/model storage.
 
 ## Roadmap

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Key files:
 - `include/ui/ui_scroll_view.h`, `src/ui/ui_scroll_view.c`: scrollable viewport wrapper with mouse-wheel input and clip-rect rendering.
 - `include/ui/ui_fps_counter.h`, `src/ui/ui_fps_counter.c`: self-updating FPS label anchored to viewport bottom-right.
 - `include/ui/ui_window.h`, `src/ui/ui_window.c`: non-rendering root parent element used for window-relative anchoring.
+- `include/util/fail_fast.h`, `src/util/fail_fast.c`: shared fail-fast logger/abort helper for unrecoverable internal errors.
 
 ### Frame/Lifecycle Flow
 
@@ -176,7 +177,7 @@ In short: resize updates page-level geometry immediately, and container-based ch
 
 - Element constructors (`ui_button_create`, `ui_pane_create`, etc.) allocate on the heap and return ownership to caller.
 - After `ui_runtime_add` succeeds, ownership transfers to `ui_runtime`.
-- Sample page constructors (`todo_page_create`, `corners_page_create`, `showcase_page_create`) now follow a fail-fast policy for unrecoverable internal failures (allocation/creation/registration): they log a critical error and abort instead of returning a recoverable error to callers.
+- Sample page lifecycle callbacks (`create`/`resize`/`update`/`destroy`) follow a fail-fast policy for unrecoverable internal failures and invalid internal state: they log a critical error and abort instead of returning recoverable errors.
 - `todo_page_destroy` removes and destroys elements that were registered by the page, then frees page-owned task/model storage.
 
 ## Roadmap

--- a/include/pages/app_page.h
+++ b/include/pages/app_page.h
@@ -17,10 +17,12 @@
  *
  * Behavior/contract:
  * - Implementations must return a non-NULL page instance from `create` on
- *   success and NULL on failure.
- * - `resize` and `update` return true on success and false on failure.
- * - `destroy` must accept NULL and release all resources owned by the page
- *   instance when non-NULL.
+ *   success.
+ * - Implementations are expected to fail fast for unrecoverable internal
+ *   failures instead of returning recoverable errors.
+ * - `resize` and `update` return true on success.
+ * - `destroy` requires a non-NULL page instance and releases all owned
+ *   resources.
  */
 typedef struct app_page_ops
 {
@@ -35,7 +37,6 @@ typedef struct app_page_ops
      *
      * Return value:
      * - Opaque page instance on success.
-     * - NULL on failure.
      */
     void *(*create)(SDL_Window *window, ui_runtime *context, int viewport_width,
                     int viewport_height);
@@ -50,7 +51,6 @@ typedef struct app_page_ops
      *
      * Return value:
      * - true on success.
-     * - false on failure.
      */
     bool (*resize)(void *page_instance, int viewport_width, int viewport_height);
 
@@ -62,7 +62,6 @@ typedef struct app_page_ops
      *
      * Return value:
      * - true on success.
-     * - false on failure.
      */
     bool (*update)(void *page_instance);
 
@@ -70,7 +69,7 @@ typedef struct app_page_ops
      * Destroy page instance and release all owned resources.
      *
      * Parameters:
-     * - `page_instance`: page created by `create`; NULL allowed.
+     * - `page_instance`: non-NULL page instance created by `create`.
      */
     void (*destroy)(void *page_instance);
 } app_page_ops;

--- a/include/pages/corners_page.h
+++ b/include/pages/corners_page.h
@@ -23,8 +23,8 @@ typedef struct corners_page corners_page;
  *
  * Behavior/contract:
  * - On success, returns a valid `corners_page *`.
- * - On failure, destroys any partially created/registered elements and returns
- *   NULL.
+ * - On unrecoverable internal failure (allocation/creation/registration),
+ *   the page logs a critical error and aborts the process (fail-fast policy).
  *
  * Parameters:
  * - `window`: SDL window handle (unused by this page, but kept for a common
@@ -36,7 +36,6 @@ typedef struct corners_page corners_page;
  *
  * Return value:
  * - Non-NULL page handle on success.
- * - NULL on allocation/creation/registration failure.
  *
  * Ownership/lifecycle:
  * - Caller owns the returned `corners_page *` and must release it with
@@ -58,7 +57,7 @@ corners_page *corners_page_create(SDL_Window *window, ui_runtime *context, int v
  *
  * Return value:
  * - true on success.
- * - false on invalid arguments.
+ * - This function follows fail-fast semantics for invalid state.
  *
  * Ownership/lifecycle:
  * - Does not transfer ownership.
@@ -72,8 +71,8 @@ bool corners_page_resize(corners_page *page, int viewport_width, int viewport_he
  * - `page`: page instance returned by `corners_page_create`.
  *
  * Return value:
- * - true when page is valid.
- * - false when `page` is NULL.
+ * - true when update succeeds.
+ * - This function follows fail-fast semantics for invalid state.
  */
 bool corners_page_update(corners_page *page);
 
@@ -81,7 +80,7 @@ bool corners_page_update(corners_page *page);
  * Destroy a corners page and release its resources.
  *
  * Parameters:
- * - `page`: page instance to destroy; NULL is allowed.
+ * - `page`: page instance to destroy; must be non-NULL.
  *
  * Ownership/lifecycle:
  * - After this call, `page` is invalid and must not be reused.

--- a/include/pages/showcase_page.h
+++ b/include/pages/showcase_page.h
@@ -22,7 +22,8 @@ typedef struct showcase_page showcase_page;
  *
  * Behavior/contract:
  * - Returns a valid `showcase_page *` on success.
- * - Returns NULL on allocation, creation, or registration failure.
+ * - On unrecoverable internal failure (allocation/creation/registration),
+ *   the page logs a critical error and aborts the process (fail-fast policy).
  *
  * Parameters:
  * - `window`: SDL window used by controls that require a window handle.
@@ -50,7 +51,7 @@ showcase_page *showcase_page_create(SDL_Window *window, ui_runtime *context, int
  *
  * Return value:
  * - true on success.
- * - false on invalid arguments.
+ * - This function follows fail-fast semantics for invalid state.
  */
 bool showcase_page_resize(showcase_page *page, int viewport_width, int viewport_height);
 
@@ -61,8 +62,8 @@ bool showcase_page_resize(showcase_page *page, int viewport_width, int viewport_
  * - `page`: page instance returned by `showcase_page_create`.
  *
  * Return value:
- * - true when page is valid.
- * - false when `page` is NULL.
+ * - true when update succeeds.
+ * - This function follows fail-fast semantics for invalid state.
  */
 bool showcase_page_update(showcase_page *page);
 
@@ -70,7 +71,7 @@ bool showcase_page_update(showcase_page *page);
  * Destroy a showcase page and release all owned resources.
  *
  * Parameters:
- * - `page`: page instance to destroy; NULL is allowed.
+ * - `page`: page instance to destroy; must be non-NULL.
  */
 void showcase_page_destroy(showcase_page *page);
 

--- a/include/pages/todo_page.h
+++ b/include/pages/todo_page.h
@@ -25,8 +25,8 @@ typedef struct todo_page todo_page;
  * Behavior/contract:
  * - On success, returns a valid `todo_page *` whose elements are owned by
  *   `context` until removed.
- * - On failure, all partially registered page elements are rolled back and
- *   destroyed, and this function returns NULL.
+ * - On unrecoverable internal failure (allocation/creation/registration),
+ *   the page logs a critical error and aborts the process (fail-fast policy).
  *
  * Parameters:
  * - `window`: SDL window used by controls that require an owning window
@@ -40,7 +40,6 @@ typedef struct todo_page todo_page;
  *
  * Return value:
  * - Non-NULL page handle on success.
- * - NULL on allocation/creation/registration failure.
  *
  * Ownership/lifecycle:
  * - Caller owns the returned `todo_page *` and must release it with
@@ -65,7 +64,7 @@ todo_page *todo_page_create(SDL_Window *window, ui_runtime *context, int viewpor
  *
  * Return value:
  * - true on success.
- * - false if `page` is NULL or row rebuild fails.
+ * - This function follows fail-fast semantics for invalid state.
  *
  * Ownership/lifecycle:
  * - Does not transfer ownership. Safe to call on every resize event.
@@ -85,7 +84,7 @@ bool todo_page_resize(todo_page *page, int viewport_width, int viewport_height);
  *
  * Return value:
  * - true when update succeeds or no work is required.
- * - false if required UI state could not be updated.
+ * - This function follows fail-fast semantics for invalid state.
  *
  * Ownership/lifecycle:
  * - Does not transfer ownership.
@@ -102,7 +101,7 @@ bool todo_page_update(todo_page *page);
  * - Free the page object itself.
  *
  * Parameters:
- * - `page`: page instance to destroy; NULL is allowed.
+ * - `page`: page instance to destroy; must be non-NULL.
  *
  * Ownership/lifecycle:
  * - After this call, `page` is invalid and must not be reused.

--- a/include/util/fail_fast.h
+++ b/include/util/fail_fast.h
@@ -1,0 +1,26 @@
+#ifndef FAIL_FAST_H
+#define FAIL_FAST_H
+
+/*
+ * Abort the process after logging a critical formatted message.
+ *
+ * Purpose:
+ * - Provide a single fail-fast utility for unrecoverable internal errors.
+ *
+ * Behavior/contract:
+ * - Logs using SDL's application logger at critical priority.
+ * - Always terminates the process via abort().
+ *
+ * Parameters:
+ * - `format`: printf-style format string (must be non-NULL).
+ * - `...`: format arguments consumed according to `format`.
+ *
+ * Return value:
+ * - This function never returns.
+ *
+ * Ownership/lifecycle:
+ * - Stateless utility; no owned resources.
+ */
+_Noreturn void fail_fast(const char *format, ...);
+
+#endif

--- a/main.c
+++ b/main.c
@@ -2,6 +2,7 @@
 
 #include "pages/app_page.h"
 #include "system/ui_runtime.h"
+#include "util/fail_fast.h"
 
 #include <errno.h>
 #include <limits.h>
@@ -67,10 +68,11 @@ static void log_available_pages(void)
     SDL_Log("Pages:");
     for (size_t i = 0U; i < app_page_count; ++i)
     {
-        if (app_pages[i].id != NULL)
+        if (app_pages[i].id == NULL)
         {
-            SDL_Log("  %s", app_pages[i].id);
+            fail_fast("page index contains NULL id at index %zu", i);
         }
+        SDL_Log("  %s", app_pages[i].id);
     }
 }
 
@@ -89,14 +91,14 @@ static const app_page_entry *find_page_descriptor_by_id(const char *page_id)
 {
     if (page_id == NULL)
     {
-        return NULL;
+        fail_fast("find_page_descriptor_by_id called with NULL page_id");
     }
 
     for (size_t i = 0U; i < app_page_count; ++i)
     {
         if (app_pages[i].id == NULL)
         {
-            continue;
+            fail_fast("page index contains NULL id at index %zu", i);
         }
         if (strcmp(app_pages[i].id, page_id) == 0)
         {
@@ -118,7 +120,7 @@ static parse_result parse_startup_options(int argc, char **argv, startup_options
 {
     if (options == NULL)
     {
-        return PARSE_RESULT_ERROR;
+        fail_fast("parse_startup_options called with NULL options");
     }
 
     for (int i = 1; i < argc; i++)

--- a/src/pages/corners_page.c
+++ b/src/pages/corners_page.c
@@ -2,8 +2,8 @@
 
 #include "ui/ui_button.h"
 #include "ui/ui_window.h"
+#include "util/fail_fast.h"
 
-#include <stdarg.h>
 #include <stdlib.h>
 
 typedef enum corner_button_slot
@@ -54,15 +54,6 @@ static const anchored_button_spec BUTTON_SPECS[CORNER_BUTTON_COUNT] = {
                                     EDGE_MARGIN},
 };
 
-static _Noreturn void fail_fast(const char *format, ...)
-{
-    va_list args;
-    va_start(args, format);
-    SDL_LogMessageV(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_CRITICAL, format, args);
-    va_end(args);
-    abort();
-}
-
 static void handle_corner_button_click(void *context) { (void)context; }
 
 static ui_button *create_anchored_button(const anchored_button_spec *spec, ui_element *parent)
@@ -93,7 +84,7 @@ static void remove_registered_elements(corners_page *page)
 {
     if (page == NULL || page->context == NULL)
     {
-        return;
+        fail_fast("corners_page: invalid state in remove_registered_elements");
     }
 
     for (size_t i = 0U; i < SDL_arraysize(page->buttons); ++i)

--- a/src/pages/showcase_page.c
+++ b/src/pages/showcase_page.c
@@ -13,8 +13,8 @@
 #include "ui/ui_text.h"
 #include "ui/ui_text_input.h"
 #include "ui/ui_window.h"
+#include "util/fail_fast.h"
 
-#include <stdarg.h>
 #include <stdlib.h>
 
 struct showcase_page
@@ -46,15 +46,6 @@ static const float FOOTER_RESERVE = 40.0F;
 static const float MAIN_SCROLL_STEP = 24.0F;
 static const char *SHOWCASE_SEGMENTS[] = {"FIRST", "SECOND", "THIRD"};
 
-static _Noreturn void fail_fast(const char *format, ...)
-{
-    va_list args;
-    va_start(args, format);
-    SDL_LogMessageV(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_CRITICAL, format, args);
-    va_end(args);
-    abort();
-}
-
 static void register_element(showcase_page *page, ui_element *element)
 {
     if (page == NULL || page->context == NULL || element == NULL)
@@ -79,7 +70,7 @@ static void unregister_elements(showcase_page *page)
 {
     if (page == NULL || page->context == NULL)
     {
-        return;
+        fail_fast("showcase_page: invalid state in unregister_elements");
     }
 
     for (size_t i = page->registered_count; i > 0U; --i)

--- a/src/pages/showcase_page.c
+++ b/src/pages/showcase_page.c
@@ -14,6 +14,7 @@
 #include "ui/ui_text_input.h"
 #include "ui/ui_window.h"
 
+#include <stdarg.h>
 #include <stdlib.h>
 
 struct showcase_page
@@ -45,35 +46,33 @@ static const float FOOTER_RESERVE = 40.0F;
 static const float MAIN_SCROLL_STEP = 24.0F;
 static const char *SHOWCASE_SEGMENTS[] = {"FIRST", "SECOND", "THIRD"};
 
-static void destroy_element(ui_element *element)
+static _Noreturn void fail_fast(const char *format, ...)
 {
-    if (element != NULL && element->ops != NULL && element->ops->destroy != NULL)
-    {
-        element->ops->destroy(element);
-    }
+    va_list args;
+    va_start(args, format);
+    SDL_LogMessageV(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_CRITICAL, format, args);
+    va_end(args);
+    abort();
 }
 
-static bool register_element(showcase_page *page, ui_element *element)
+static void register_element(showcase_page *page, ui_element *element)
 {
     if (page == NULL || page->context == NULL || element == NULL)
     {
-        return false;
+        fail_fast("showcase_page: invalid register_element input");
     }
 
     if (!ui_runtime_add(page->context, element))
     {
-        destroy_element(element);
-        return false;
+        fail_fast("showcase_page: ui_runtime_add failed");
     }
 
     if (page->registered_count >= SDL_arraysize(page->registered_elements))
     {
-        (void)ui_runtime_remove(page->context, element, true);
-        return false;
+        fail_fast("showcase_page: registered element tracker capacity exceeded");
     }
 
     page->registered_elements[page->registered_count++] = element;
-    return true;
 }
 
 static void unregister_elements(showcase_page *page)
@@ -92,31 +91,30 @@ static void unregister_elements(showcase_page *page)
     page->registered_count = 0U;
 }
 
-static bool add_child_or_fail(ui_layout_container *container, ui_element *child)
+static void add_child_or_fail(ui_layout_container *container, ui_element *child)
 {
-    if (!ui_layout_container_add_child(container, child))
+    if (container == NULL || child == NULL)
     {
-        destroy_element(child);
-        return false;
+        fail_fast("showcase_page: invalid add_child_or_fail input");
     }
 
-    return true;
+    if (!ui_layout_container_add_child(container, child))
+    {
+        fail_fast("showcase_page: failed to add child to layout container");
+    }
 }
 
-static bool set_text_content(ui_text *text, const char *content)
+static void set_text_content(ui_text *text, const char *content)
 {
     if (text == NULL || content == NULL)
     {
-        return false;
+        fail_fast("showcase_page: invalid set_text_content input");
     }
 
     if (!ui_text_set_content(text, content))
     {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to update showcase text: %s", content);
-        return false;
+        fail_fast("showcase_page: failed to update text content");
     }
-
-    return true;
 }
 
 static void handle_demo_button_click(void *context)
@@ -124,10 +122,10 @@ static void handle_demo_button_click(void *context)
     showcase_page *page = (showcase_page *)context;
     if (page == NULL)
     {
-        return;
+        fail_fast("showcase_page: demo button callback context is NULL");
     }
 
-    (void)set_text_content(page->status_text, "BUTTON CLICKED");
+    set_text_content(page->status_text, "BUTTON CLICKED");
 }
 
 static void handle_checkbox_change(bool checked, void *context)
@@ -135,10 +133,10 @@ static void handle_checkbox_change(bool checked, void *context)
     showcase_page *page = (showcase_page *)context;
     if (page == NULL)
     {
-        return;
+        fail_fast("showcase_page: checkbox callback context is NULL");
     }
 
-    (void)set_text_content(page->checkbox_state_text, checked ? "CHECKBOX: ON" : "CHECKBOX: OFF");
+    set_text_content(page->checkbox_state_text, checked ? "CHECKBOX: ON" : "CHECKBOX: OFF");
 }
 
 static void handle_slider_change(float value, void *context)
@@ -146,26 +144,26 @@ static void handle_slider_change(float value, void *context)
     showcase_page *page = (showcase_page *)context;
     if (page == NULL || page->slider_value_text == NULL)
     {
-        return;
+        fail_fast("showcase_page: slider callback state is invalid");
     }
 
     char slider_label[64];
     SDL_snprintf(slider_label, sizeof(slider_label), "SLIDER VALUE: %.1f", value);
-    (void)set_text_content(page->slider_value_text, slider_label);
+    set_text_content(page->slider_value_text, slider_label);
 }
 
 static void handle_segment_change(size_t selected_index, const char *selected_label, void *context)
 {
     showcase_page *page = (showcase_page *)context;
-    if (page == NULL || page->segment_value_text == NULL)
+    if (page == NULL || page->segment_value_text == NULL || selected_label == NULL)
     {
-        return;
+        fail_fast("showcase_page: segment callback state is invalid");
     }
 
     char segment_label[80];
     SDL_snprintf(segment_label, sizeof(segment_label), "SEGMENT %zu: %s", selected_index + 1U,
                  selected_label);
-    (void)set_text_content(page->segment_value_text, segment_label);
+    set_text_content(page->segment_value_text, segment_label);
 }
 
 static void handle_text_input_submit(const char *value, void *context)
@@ -173,7 +171,7 @@ static void handle_text_input_submit(const char *value, void *context)
     showcase_page *page = (showcase_page *)context;
     if (page == NULL || value == NULL)
     {
-        return;
+        fail_fast("showcase_page: text-input callback state is invalid");
     }
 
     char submitted[160];
@@ -186,12 +184,24 @@ static void handle_text_input_submit(const char *value, void *context)
         SDL_snprintf(submitted, sizeof(submitted), "INPUT SUBMIT: %s", value);
     }
 
-    (void)set_text_content(page->status_text, submitted);
+    set_text_content(page->status_text, submitted);
 }
 
-static ui_text *create_text_label(const char *content, SDL_Color color)
+static ui_text *create_text_label_or_fail(const char *content, SDL_Color color)
 {
-    return ui_text_create(0.0F, 0.0F, content, color, NULL);
+    ui_text *label = ui_text_create(0.0F, 0.0F, content, color, NULL);
+    if (label == NULL)
+    {
+        fail_fast("showcase_page: failed to create text label");
+    }
+
+    return label;
+}
+
+static void add_text_label(ui_layout_container *content, const char *label, SDL_Color color)
+{
+    ui_text *text = create_text_label_or_fail(label, color);
+    add_child_or_fail(content, (ui_element *)text);
 }
 
 static ui_layout_container *create_showcase_content(showcase_page *page, SDL_Window *window,
@@ -199,7 +209,7 @@ static ui_layout_container *create_showcase_content(showcase_page *page, SDL_Win
 {
     if (page == NULL || window == NULL || renderer == NULL)
     {
-        return NULL;
+        fail_fast("showcase_page: invalid create_showcase_content input");
     }
 
     const SDL_Color color_ink = {31, 34, 44, 255};
@@ -222,266 +232,158 @@ static ui_layout_container *create_showcase_content(showcase_page *page, SDL_Win
         &(SDL_FRect){0.0F, 0.0F, 720.0F, 1200.0F}, UI_LAYOUT_AXIS_VERTICAL, &color_border);
     if (content == NULL)
     {
-        return NULL;
+        fail_fast("showcase_page: failed to create content container");
     }
 
-    ui_text *title = create_text_label("UI SHOWCASE PAGE", color_ink);
-    if (title == NULL || !add_child_or_fail(content, (ui_element *)title))
-    {
-        destroy_element((ui_element *)title);
-        destroy_element((ui_element *)content);
-        return NULL;
-    }
-
-    ui_text *subtitle = create_text_label("Every built-in widget on one page", color_muted);
-    if (subtitle == NULL || !add_child_or_fail(content, (ui_element *)subtitle))
-    {
-        destroy_element((ui_element *)subtitle);
-        destroy_element((ui_element *)content);
-        return NULL;
-    }
+    add_text_label(content, "UI SHOWCASE PAGE", color_ink);
+    add_text_label(content, "Every built-in widget on one page", color_muted);
 
     ui_hrule *top_rule = ui_hrule_create(8.0F, color_line, 0.0F);
-    if (top_rule == NULL || !add_child_or_fail(content, (ui_element *)top_rule))
+    if (top_rule == NULL)
     {
-        destroy_element((ui_element *)top_rule);
-        destroy_element((ui_element *)content);
-        return NULL;
+        fail_fast("showcase_page: failed to create top rule");
     }
+    add_child_or_fail(content, (ui_element *)top_rule);
 
-    ui_text *pane_label = create_text_label("UI_PANE", color_ink);
-    if (pane_label == NULL || !add_child_or_fail(content, (ui_element *)pane_label))
-    {
-        destroy_element((ui_element *)pane_label);
-        destroy_element((ui_element *)content);
-        return NULL;
-    }
+    add_text_label(content, "UI_PANE", color_ink);
 
     ui_pane *pane =
         ui_pane_create(&(SDL_FRect){0.0F, 0.0F, 100.0F, 56.0F}, color_pane_fill, &color_border);
-    if (pane == NULL || !add_child_or_fail(content, (ui_element *)pane))
+    if (pane == NULL)
     {
-        destroy_element((ui_element *)pane);
-        destroy_element((ui_element *)content);
-        return NULL;
+        fail_fast("showcase_page: failed to create demo pane");
     }
+    add_child_or_fail(content, (ui_element *)pane);
 
     ui_hrule *controls_rule = ui_hrule_create(8.0F, color_line, 0.0F);
-    if (controls_rule == NULL || !add_child_or_fail(content, (ui_element *)controls_rule))
+    if (controls_rule == NULL)
     {
-        destroy_element((ui_element *)controls_rule);
-        destroy_element((ui_element *)content);
-        return NULL;
+        fail_fast("showcase_page: failed to create controls rule");
     }
+    add_child_or_fail(content, (ui_element *)controls_rule);
 
-    ui_text *controls_label = create_text_label("UI_BUTTON + UI_CHECKBOX", color_ink);
-    if (controls_label == NULL || !add_child_or_fail(content, (ui_element *)controls_label))
-    {
-        destroy_element((ui_element *)controls_label);
-        destroy_element((ui_element *)content);
-        return NULL;
-    }
+    add_text_label(content, "UI_BUTTON + UI_CHECKBOX", color_ink);
 
     ui_layout_container *controls_row = ui_layout_container_create(
         &(SDL_FRect){0.0F, 0.0F, 100.0F, 44.0F}, UI_LAYOUT_AXIS_HORIZONTAL, NULL);
     if (controls_row == NULL)
     {
-        destroy_element((ui_element *)content);
-        return NULL;
+        fail_fast("showcase_page: failed to create controls row");
     }
 
     ui_button *button = ui_button_create(&(SDL_FRect){0.0F, 0.0F, 160.0F, 32.0F}, color_button_up,
                                          color_button_down, "CLICK BUTTON", &color_border,
                                          handle_demo_button_click, page);
-    if (button == NULL || !add_child_or_fail(controls_row, (ui_element *)button))
+    if (button == NULL)
     {
-        destroy_element((ui_element *)button);
-        destroy_element((ui_element *)controls_row);
-        destroy_element((ui_element *)content);
-        return NULL;
+        fail_fast("showcase_page: failed to create demo button");
     }
+    add_child_or_fail(controls_row, (ui_element *)button);
 
     page->checkbox = ui_checkbox_create(0.0F, 0.0F, "TOGGLE CHECKBOX", color_ink, color_ink,
                                         color_ink, false, handle_checkbox_change, page, NULL);
-    if (page->checkbox == NULL || !add_child_or_fail(controls_row, (ui_element *)page->checkbox))
+    if (page->checkbox == NULL)
     {
-        destroy_element((ui_element *)page->checkbox);
-        page->checkbox = NULL;
-        destroy_element((ui_element *)controls_row);
-        destroy_element((ui_element *)content);
-        return NULL;
+        fail_fast("showcase_page: failed to create checkbox");
     }
+    add_child_or_fail(controls_row, (ui_element *)page->checkbox);
 
-    if (!add_child_or_fail(content, (ui_element *)controls_row))
-    {
-        destroy_element((ui_element *)controls_row);
-        destroy_element((ui_element *)content);
-        return NULL;
-    }
+    add_child_or_fail(content, (ui_element *)controls_row);
 
-    page->checkbox_state_text = create_text_label("CHECKBOX: OFF", color_muted);
-    if (page->checkbox_state_text == NULL ||
-        !add_child_or_fail(content, (ui_element *)page->checkbox_state_text))
-    {
-        destroy_element((ui_element *)page->checkbox_state_text);
-        page->checkbox_state_text = NULL;
-        destroy_element((ui_element *)content);
-        return NULL;
-    }
+    page->checkbox_state_text = create_text_label_or_fail("CHECKBOX: OFF", color_muted);
+    add_child_or_fail(content, (ui_element *)page->checkbox_state_text);
 
     ui_hrule *input_rule = ui_hrule_create(8.0F, color_line, 0.0F);
-    if (input_rule == NULL || !add_child_or_fail(content, (ui_element *)input_rule))
+    if (input_rule == NULL)
     {
-        destroy_element((ui_element *)input_rule);
-        destroy_element((ui_element *)content);
-        return NULL;
+        fail_fast("showcase_page: failed to create input rule");
     }
+    add_child_or_fail(content, (ui_element *)input_rule);
 
-    ui_text *input_label = create_text_label("UI_TEXT_INPUT", color_ink);
-    if (input_label == NULL || !add_child_or_fail(content, (ui_element *)input_label))
-    {
-        destroy_element((ui_element *)input_label);
-        destroy_element((ui_element *)content);
-        return NULL;
-    }
+    add_text_label(content, "UI_TEXT_INPUT", color_ink);
 
     ui_text_input *text_input =
         ui_text_input_create(&(SDL_FRect){0.0F, 0.0F, 520.0F, 36.0F}, color_ink, color_input_bg,
                              color_border, color_focus_border, "Type and press Enter", color_muted,
                              window, handle_text_input_submit, page);
-    if (text_input == NULL || !add_child_or_fail(content, (ui_element *)text_input))
+    if (text_input == NULL)
     {
-        destroy_element((ui_element *)text_input);
-        destroy_element((ui_element *)content);
-        return NULL;
+        fail_fast("showcase_page: failed to create text input");
     }
+    add_child_or_fail(content, (ui_element *)text_input);
 
-    page->status_text = create_text_label("BUTTON/INPUT STATUS: READY", color_muted);
-    if (page->status_text == NULL || !add_child_or_fail(content, (ui_element *)page->status_text))
-    {
-        destroy_element((ui_element *)page->status_text);
-        page->status_text = NULL;
-        destroy_element((ui_element *)content);
-        return NULL;
-    }
+    page->status_text = create_text_label_or_fail("BUTTON/INPUT STATUS: READY", color_muted);
+    add_child_or_fail(content, (ui_element *)page->status_text);
 
     ui_hrule *segment_rule = ui_hrule_create(8.0F, color_line, 0.0F);
-    if (segment_rule == NULL || !add_child_or_fail(content, (ui_element *)segment_rule))
+    if (segment_rule == NULL)
     {
-        destroy_element((ui_element *)segment_rule);
-        destroy_element((ui_element *)content);
-        return NULL;
+        fail_fast("showcase_page: failed to create segment rule");
     }
+    add_child_or_fail(content, (ui_element *)segment_rule);
 
-    ui_text *segment_label = create_text_label("UI_SEGMENT_GROUP", color_ink);
-    if (segment_label == NULL || !add_child_or_fail(content, (ui_element *)segment_label))
-    {
-        destroy_element((ui_element *)segment_label);
-        destroy_element((ui_element *)content);
-        return NULL;
-    }
+    add_text_label(content, "UI_SEGMENT_GROUP", color_ink);
 
     page->segment_group = ui_segment_group_create(
         &(SDL_FRect){0.0F, 0.0F, 420.0F, 36.0F}, SHOWCASE_SEGMENTS,
         SDL_arraysize(SHOWCASE_SEGMENTS), 0U, color_segment_bg, color_segment_selected,
         color_segment_pressed, color_ink, (SDL_Color){244, 246, 255, 255}, &color_border,
         handle_segment_change, page);
-    if (page->segment_group == NULL ||
-        !add_child_or_fail(content, (ui_element *)page->segment_group))
+    if (page->segment_group == NULL)
     {
-        destroy_element((ui_element *)page->segment_group);
-        page->segment_group = NULL;
-        destroy_element((ui_element *)content);
-        return NULL;
+        fail_fast("showcase_page: failed to create segment group");
     }
+    add_child_or_fail(content, (ui_element *)page->segment_group);
 
-    page->segment_value_text = create_text_label("SEGMENT 1: FIRST", color_muted);
-    if (page->segment_value_text == NULL ||
-        !add_child_or_fail(content, (ui_element *)page->segment_value_text))
-    {
-        destroy_element((ui_element *)page->segment_value_text);
-        page->segment_value_text = NULL;
-        destroy_element((ui_element *)content);
-        return NULL;
-    }
+    page->segment_value_text = create_text_label_or_fail("SEGMENT 1: FIRST", color_muted);
+    add_child_or_fail(content, (ui_element *)page->segment_value_text);
 
     ui_hrule *slider_rule = ui_hrule_create(8.0F, color_line, 0.0F);
-    if (slider_rule == NULL || !add_child_or_fail(content, (ui_element *)slider_rule))
+    if (slider_rule == NULL)
     {
-        destroy_element((ui_element *)slider_rule);
-        destroy_element((ui_element *)content);
-        return NULL;
+        fail_fast("showcase_page: failed to create slider rule");
     }
+    add_child_or_fail(content, (ui_element *)slider_rule);
 
-    ui_text *slider_label = create_text_label("UI_SLIDER", color_ink);
-    if (slider_label == NULL || !add_child_or_fail(content, (ui_element *)slider_label))
-    {
-        destroy_element((ui_element *)slider_label);
-        destroy_element((ui_element *)content);
-        return NULL;
-    }
+    add_text_label(content, "UI_SLIDER", color_ink);
 
     page->slider = ui_slider_create(
         &(SDL_FRect){0.0F, 0.0F, 420.0F, 30.0F}, 0.0F, 100.0F, 35.0F, color_slider_track,
         color_slider_thumb, color_slider_thumb_active, &color_border, handle_slider_change, page);
-    if (page->slider == NULL || !add_child_or_fail(content, (ui_element *)page->slider))
+    if (page->slider == NULL)
     {
-        destroy_element((ui_element *)page->slider);
-        page->slider = NULL;
-        destroy_element((ui_element *)content);
-        return NULL;
+        fail_fast("showcase_page: failed to create slider");
     }
+    add_child_or_fail(content, (ui_element *)page->slider);
 
-    page->slider_value_text = create_text_label("SLIDER VALUE: 35.0", color_muted);
-    if (page->slider_value_text == NULL ||
-        !add_child_or_fail(content, (ui_element *)page->slider_value_text))
-    {
-        destroy_element((ui_element *)page->slider_value_text);
-        page->slider_value_text = NULL;
-        destroy_element((ui_element *)content);
-        return NULL;
-    }
+    page->slider_value_text = create_text_label_or_fail("SLIDER VALUE: 35.0", color_muted);
+    add_child_or_fail(content, (ui_element *)page->slider_value_text);
 
     ui_hrule *image_rule = ui_hrule_create(8.0F, color_line, 0.0F);
-    if (image_rule == NULL || !add_child_or_fail(content, (ui_element *)image_rule))
+    if (image_rule == NULL)
     {
-        destroy_element((ui_element *)image_rule);
-        destroy_element((ui_element *)content);
-        return NULL;
+        fail_fast("showcase_page: failed to create image rule");
     }
+    add_child_or_fail(content, (ui_element *)image_rule);
 
-    ui_text *image_label = create_text_label("UI_IMAGE", color_ink);
-    if (image_label == NULL || !add_child_or_fail(content, (ui_element *)image_label))
-    {
-        destroy_element((ui_element *)image_label);
-        destroy_element((ui_element *)content);
-        return NULL;
-    }
+    add_text_label(content, "UI_IMAGE", color_ink);
 
     ui_image *image =
         ui_image_create(renderer, 0.0F, 0.0F, 120.0F, 120.0F, "assets/icon.png", &color_border);
-    if (image == NULL || !add_child_or_fail(content, (ui_element *)image))
+    if (image == NULL)
     {
-        destroy_element((ui_element *)image);
-        destroy_element((ui_element *)content);
-        return NULL;
+        fail_fast("showcase_page: failed to create image widget");
     }
+    add_child_or_fail(content, (ui_element *)image);
 
     ui_hrule *end_rule = ui_hrule_create(8.0F, color_line, 0.0F);
-    if (end_rule == NULL || !add_child_or_fail(content, (ui_element *)end_rule))
+    if (end_rule == NULL)
     {
-        destroy_element((ui_element *)end_rule);
-        destroy_element((ui_element *)content);
-        return NULL;
+        fail_fast("showcase_page: failed to create end rule");
     }
+    add_child_or_fail(content, (ui_element *)end_rule);
 
-    ui_text *footer_text = create_text_label("END OF SHOWCASE", color_muted);
-    if (footer_text == NULL || !add_child_or_fail(content, (ui_element *)footer_text))
-    {
-        destroy_element((ui_element *)footer_text);
-        destroy_element((ui_element *)content);
-        return NULL;
-    }
+    add_text_label(content, "END OF SHOWCASE", color_muted);
 
     handle_checkbox_change(ui_checkbox_is_checked(page->checkbox), page);
     handle_slider_change(page->slider->value, page);
@@ -491,18 +393,18 @@ static ui_layout_container *create_showcase_content(showcase_page *page, SDL_Win
     return content;
 }
 
-static bool relayout_page(showcase_page *page)
+static void relayout_page(showcase_page *page)
 {
     if (page == NULL || page->window_root == NULL || page->background == NULL ||
         page->scroll_view == NULL)
     {
-        return false;
+        fail_fast("showcase_page: invalid relayout state");
     }
 
     if (!ui_window_set_size(page->window_root, (float)page->viewport_width,
                             (float)page->viewport_height))
     {
-        return false;
+        fail_fast("showcase_page: failed to resize window root");
     }
 
     page->background->base.rect.x = 0.0F;
@@ -526,8 +428,6 @@ static bool relayout_page(showcase_page *page)
     page->scroll_view->base.rect.y = PAGE_MARGIN;
     page->scroll_view->base.rect.w = scroll_width;
     page->scroll_view->base.rect.h = scroll_height;
-
-    return true;
 }
 
 showcase_page *showcase_page_create(SDL_Window *window, ui_runtime *context, int viewport_width,
@@ -535,21 +435,19 @@ showcase_page *showcase_page_create(SDL_Window *window, ui_runtime *context, int
 {
     if (window == NULL || context == NULL || viewport_width <= 0 || viewport_height <= 0)
     {
-        return NULL;
+        fail_fast("showcase_page_create called with invalid arguments");
     }
 
     SDL_Renderer *renderer = SDL_GetRenderer(window);
     if (renderer == NULL)
     {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
-                     "showcase_page_create requires window renderer: %s", SDL_GetError());
-        return NULL;
+        fail_fast("showcase_page_create requires window renderer: %s", SDL_GetError());
     }
 
     showcase_page *page = calloc(1U, sizeof(*page));
     if (page == NULL)
     {
-        return NULL;
+        fail_fast("showcase_page: failed to allocate page object");
     }
 
     page->context = context;
@@ -558,35 +456,23 @@ showcase_page *showcase_page_create(SDL_Window *window, ui_runtime *context, int
 
     page->window_root =
         ui_window_create(&(SDL_FRect){0.0F, 0.0F, (float)viewport_width, (float)viewport_height});
-    if (page->window_root == NULL || !register_element(page, (ui_element *)page->window_root))
+    if (page->window_root == NULL)
     {
-        showcase_page_destroy(page);
-        return NULL;
+        fail_fast("showcase_page: failed to create window root");
     }
+    register_element(page, (ui_element *)page->window_root);
 
     const SDL_Color color_bg = {243, 245, 250, 255};
     page->background = ui_pane_create(
         &(SDL_FRect){0.0F, 0.0F, (float)viewport_width, (float)viewport_height}, color_bg, NULL);
     if (page->background == NULL)
     {
-        showcase_page_destroy(page);
-        return NULL;
+        fail_fast("showcase_page: failed to create background pane");
     }
     page->background->base.parent = &page->window_root->base;
-
-    if (!register_element(page, (ui_element *)page->background))
-    {
-        page->background = NULL;
-        showcase_page_destroy(page);
-        return NULL;
-    }
+    register_element(page, (ui_element *)page->background);
 
     ui_layout_container *content = create_showcase_content(page, window, renderer);
-    if (content == NULL)
-    {
-        showcase_page_destroy(page);
-        return NULL;
-    }
 
     const SDL_Color color_scroll_border = {206, 209, 217, 255};
     page->scroll_view = ui_scroll_view_create(
@@ -595,41 +481,22 @@ showcase_page *showcase_page_create(SDL_Window *window, ui_runtime *context, int
         (ui_element *)content, MAIN_SCROLL_STEP, &color_scroll_border);
     if (page->scroll_view == NULL)
     {
-        destroy_element((ui_element *)content);
-        showcase_page_destroy(page);
-        return NULL;
+        fail_fast("showcase_page: failed to create scroll view");
     }
     page->scroll_view->base.parent = &page->window_root->base;
-
-    if (!register_element(page, (ui_element *)page->scroll_view))
-    {
-        page->scroll_view = NULL;
-        showcase_page_destroy(page);
-        return NULL;
-    }
+    register_element(page, (ui_element *)page->scroll_view);
 
     const SDL_Color color_fps = {56, 61, 76, 255};
     page->fps_counter =
         ui_fps_counter_create(viewport_width, viewport_height, 16.0F, color_fps, NULL);
     if (page->fps_counter == NULL)
     {
-        showcase_page_destroy(page);
-        return NULL;
+        fail_fast("showcase_page: failed to create fps counter");
     }
     page->fps_counter->base.parent = &page->window_root->base;
+    register_element(page, (ui_element *)page->fps_counter);
 
-    if (!register_element(page, (ui_element *)page->fps_counter))
-    {
-        page->fps_counter = NULL;
-        showcase_page_destroy(page);
-        return NULL;
-    }
-
-    if (!relayout_page(page))
-    {
-        showcase_page_destroy(page);
-        return NULL;
-    }
+    relayout_page(page);
 
     return page;
 }
@@ -638,21 +505,30 @@ bool showcase_page_resize(showcase_page *page, int viewport_width, int viewport_
 {
     if (page == NULL || viewport_width <= 0 || viewport_height <= 0)
     {
-        return false;
+        fail_fast("showcase_page_resize called with invalid arguments");
     }
 
     page->viewport_width = viewport_width;
     page->viewport_height = viewport_height;
-    return relayout_page(page);
+    relayout_page(page);
+    return true;
 }
 
-bool showcase_page_update(showcase_page *page) { return page != NULL; }
+bool showcase_page_update(showcase_page *page)
+{
+    if (page == NULL)
+    {
+        fail_fast("showcase_page_update called with NULL page");
+    }
+
+    return true;
+}
 
 void showcase_page_destroy(showcase_page *page)
 {
     if (page == NULL)
     {
-        return;
+        fail_fast("showcase_page_destroy called with NULL page");
     }
 
     unregister_elements(page);

--- a/src/pages/todo_page.c
+++ b/src/pages/todo_page.c
@@ -11,10 +11,10 @@
 #include "ui/ui_text.h"
 #include "ui/ui_text_input.h"
 #include "ui/ui_window.h"
+#include "util/fail_fast.h"
 #include "util/string_util.h"
 
 #include <ctype.h>
-#include <stdarg.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
@@ -115,18 +115,6 @@ static const float FILTER_H = 40.0F;
 static const char *TODO_FILTER_LABELS[] = {"ALL", "ACTIVE", "DONE"};
 
 /*
- * Abort process after logging an unrecoverable TODO-page failure.
- */
-static _Noreturn void fail_fast(const char *format, ...)
-{
-    va_list args;
-    va_start(args, format);
-    SDL_LogMessageV(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_CRITICAL, format, args);
-    va_end(args);
-    abort();
-}
-
-/*
  * Register one page-owned element into the UI context and track it for teardown.
  */
 static void register_element(todo_page *page, ui_element *element)
@@ -156,7 +144,7 @@ static void unregister_elements(todo_page *page)
 {
     if (page == NULL || page->context == NULL)
     {
-        return;
+        fail_fast("todo_page: invalid state in unregister_elements");
     }
 
     for (size_t i = page->registered_count; i > 0U; --i)
@@ -238,7 +226,7 @@ static bool does_task_match_filter(const todo_page *page, const todo_task *task)
 {
     if (page == NULL || task == NULL)
     {
-        return false;
+        fail_fast("todo_page: invalid state in does_task_match_filter");
     }
 
     switch (page->selected_filter_index)
@@ -614,7 +602,7 @@ static void clear_done_tasks(todo_page *page)
 {
     if (page == NULL)
     {
-        return;
+        fail_fast("todo_page: invalid state in clear_done_tasks");
     }
 
     size_t write = 0U;
@@ -646,7 +634,7 @@ static void destroy_task_storage(todo_page *page)
 {
     if (page == NULL)
     {
-        return;
+        fail_fast("todo_page: invalid state in destroy_task_storage");
     }
 
     for (size_t i = 0; i < page->task_count; ++i)

--- a/src/pages/todo_page.c
+++ b/src/pages/todo_page.c
@@ -14,6 +14,7 @@
 #include "util/string_util.h"
 
 #include <ctype.h>
+#include <stdarg.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
@@ -114,41 +115,38 @@ static const float FILTER_H = 40.0F;
 static const char *TODO_FILTER_LABELS[] = {"ALL", "ACTIVE", "DONE"};
 
 /*
- * Invoke an element's destructor callback when present.
+ * Abort process after logging an unrecoverable TODO-page failure.
  */
-static void destroy_element(ui_element *element)
+static _Noreturn void fail_fast(const char *format, ...)
 {
-    if (element != NULL && element->ops != NULL && element->ops->destroy != NULL)
-    {
-        element->ops->destroy(element);
-    }
+    va_list args;
+    va_start(args, format);
+    SDL_LogMessageV(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_CRITICAL, format, args);
+    va_end(args);
+    abort();
 }
 
 /*
  * Register one page-owned element into the UI context and track it for teardown.
  */
-static bool register_element(todo_page *page, ui_element *element)
+static void register_element(todo_page *page, ui_element *element)
 {
     if (page == NULL || page->context == NULL || element == NULL)
     {
-        return false;
+        fail_fast("todo_page: invalid register_element input");
     }
 
     if (!ui_runtime_add(page->context, element))
     {
-        // If registration fails, ownership never transfers to ui_runtime.
-        destroy_element(element);
-        return false;
+        fail_fast("todo_page: ui_runtime_add failed during registration");
     }
 
     if (page->registered_count >= SDL_arraysize(page->registered_elements))
     {
-        (void)ui_runtime_remove(page->context, element, true);
-        return false;
+        fail_fast("todo_page: registered element tracker capacity exceeded");
     }
 
     page->registered_elements[page->registered_count++] = element;
-    return true;
 }
 
 /*
@@ -171,26 +169,29 @@ static void unregister_elements(todo_page *page)
 }
 
 /*
- * Add a child to a layout container, destroying the child on failure.
+ * Add a child to a layout container.
  */
-static bool add_child_or_fail(ui_layout_container *container, ui_element *child)
+static void add_child_or_fail(ui_layout_container *container, ui_element *child)
 {
+    if (container == NULL || child == NULL)
+    {
+        fail_fast("todo_page: invalid child add input");
+    }
+
     if (!ui_layout_container_add_child(container, child))
     {
-        destroy_element(child);
-        return false;
+        fail_fast("todo_page: ui_layout_container_add_child failed");
     }
-    return true;
 }
 
 /*
  * Recompute and refresh the "active/done/remaining" summary labels.
  */
-static bool update_task_summary(todo_page *page)
+static void update_task_summary(todo_page *page)
 {
     if (page == NULL || page->stats_text == NULL || page->remaining_text == NULL)
     {
-        return false;
+        fail_fast("todo_page: summary update called with invalid state");
     }
 
     size_t done_count = 0U;
@@ -212,17 +213,15 @@ static bool update_task_summary(todo_page *page)
 
     if (!ui_text_set_content(page->stats_text, stats_buffer))
     {
-        return false;
+        fail_fast("todo_page: failed to update stats summary text");
     }
     if (!ui_text_set_content(page->remaining_text, remaining_buffer))
     {
-        return false;
+        fail_fast("todo_page: failed to update remaining summary text");
     }
-
-    return true;
 }
 
-static bool rebuild_task_rows(todo_page *page);
+static void rebuild_task_rows(todo_page *page);
 
 /*
  * Compute the usable content width from viewport width and horizontal margins.
@@ -257,11 +256,11 @@ static bool does_task_match_filter(const todo_page *page, const todo_task *task)
 /*
  * Ensure per-row callback context storage can index every task entry.
  */
-static bool ensure_row_context_capacity(todo_page *page)
+static void ensure_row_context_capacity(todo_page *page)
 {
     if (page == NULL)
     {
-        return false;
+        fail_fast("todo_page: NULL page in ensure_row_context_capacity");
     }
 
     if (page->task_count == 0U)
@@ -269,12 +268,12 @@ static bool ensure_row_context_capacity(todo_page *page)
         free(page->row_contexts);
         page->row_contexts = NULL;
         page->row_context_capacity = 0U;
-        return true;
+        return;
     }
 
     if (page->row_context_capacity >= page->task_count)
     {
-        return true;
+        return;
     }
 
     // Context slots are indexed by task index, so capacity follows task_count.
@@ -283,22 +282,21 @@ static bool ensure_row_context_capacity(todo_page *page)
         realloc((void *)page->row_contexts, new_capacity * sizeof(task_row_context));
     if (new_contexts == NULL)
     {
-        return false;
+        fail_fast("todo_page: failed to grow row contexts");
     }
 
     page->row_contexts = new_contexts;
     page->row_context_capacity = new_capacity;
-    return true;
 }
 
 /*
  * Delete a task by index and rebuild visible rows afterward.
  */
-static bool delete_task_at_index(todo_page *page, size_t index)
+static void delete_task_at_index(todo_page *page, size_t index)
 {
     if (page == NULL || index >= page->task_count)
     {
-        return false;
+        fail_fast("todo_page: invalid delete index");
     }
 
     free(page->tasks[index].title);
@@ -310,7 +308,7 @@ static bool delete_task_at_index(todo_page *page, size_t index)
     }
     page->task_count--;
 
-    return rebuild_task_rows(page);
+    rebuild_task_rows(page);
 }
 
 /*
@@ -321,14 +319,10 @@ static void handle_delete_button_click(void *context)
     task_row_context *row_ctx = (task_row_context *)context;
     if (row_ctx == NULL || row_ctx->page == NULL)
     {
-        return;
+        fail_fast("todo_page: delete callback context is invalid");
     }
 
-    if (!delete_task_at_index(row_ctx->page, row_ctx->task_index))
-    {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to delete task at index %zu",
-                     row_ctx->task_index);
-    }
+    delete_task_at_index(row_ctx->page, row_ctx->task_index);
 }
 
 /*
@@ -339,30 +333,27 @@ static void handle_task_checkbox_change(bool checked, void *context)
     task_row_context *row_ctx = (task_row_context *)context;
     if (row_ctx == NULL || row_ctx->page == NULL)
     {
-        return;
+        fail_fast("todo_page: checkbox callback context is invalid");
     }
 
     todo_page *page = row_ctx->page;
     if (row_ctx->task_index >= page->task_count)
     {
-        return;
+        fail_fast("todo_page: checkbox callback received out-of-range task index");
     }
 
     page->tasks[row_ctx->task_index].is_done = checked;
-    if (!rebuild_task_rows(page))
-    {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to rebuild rows after toggle");
-    }
+    rebuild_task_rows(page);
 }
 
 /*
  * Build one horizontal UI row for the task at the provided model index.
  */
-static bool add_task_row(todo_page *page, size_t index)
+static void add_task_row(todo_page *page, size_t index)
 {
     if (page == NULL || page->rows_container == NULL || index >= page->task_count)
     {
-        return false;
+        fail_fast("todo_page: invalid add_task_row input");
     }
 
     const todo_task *task = &page->tasks[index];
@@ -373,7 +364,7 @@ static bool add_task_row(todo_page *page, size_t index)
         &(SDL_FRect){0.0F, 0.0F, 0.0F, ROW_HEIGHT}, UI_LAYOUT_AXIS_HORIZONTAL, &page->color_ink);
     if (row == NULL)
     {
-        return false;
+        fail_fast("todo_page: failed to create task row container");
     }
 
     task_row_context *row_ctx = &page->row_contexts[index];
@@ -383,96 +374,62 @@ static bool add_task_row(todo_page *page, size_t index)
     ui_text *number = ui_text_create(0.0F, 0.0F, row_number, page->color_muted, NULL);
     if (number == NULL)
     {
-        destroy_element((ui_element *)row);
-        return false;
+        fail_fast("todo_page: failed to create task number text");
     }
     number->base.rect.w = COL_NUMBER_W;
-    if (!add_child_or_fail(row, (ui_element *)number))
-    {
-        destroy_element((ui_element *)row);
-        return false;
-    }
+    add_child_or_fail(row, (ui_element *)number);
 
     ui_checkbox *check =
         ui_checkbox_create(0.0F, 0.0F, "", page->color_ink, page->color_ink, page->color_ink,
                            task->is_done, handle_task_checkbox_change, row_ctx, NULL);
     if (check == NULL)
     {
-        destroy_element((ui_element *)row);
-        return false;
+        fail_fast("todo_page: failed to create task checkbox");
     }
     check->base.rect.w = COL_CHECK_W;
-    if (!add_child_or_fail(row, (ui_element *)check))
-    {
-        destroy_element((ui_element *)row);
-        return false;
-    }
+    add_child_or_fail(row, (ui_element *)check);
 
     ui_text *task_text = ui_text_create(0.0F, 0.0F, task->title, page->color_ink, NULL);
     if (task_text == NULL)
     {
-        destroy_element((ui_element *)row);
-        return false;
+        fail_fast("todo_page: failed to create task title text");
     }
     task_text->base.rect.w = COL_TITLE_W;
-    if (!add_child_or_fail(row, (ui_element *)task_text))
-    {
-        destroy_element((ui_element *)row);
-        return false;
-    }
+    add_child_or_fail(row, (ui_element *)task_text);
 
     ui_text *time_text = ui_text_create(0.0F, 0.0F, task->due_time, page->color_muted, NULL);
     if (time_text == NULL)
     {
-        destroy_element((ui_element *)row);
-        return false;
+        fail_fast("todo_page: failed to create task due-time text");
     }
     time_text->base.rect.w = COL_TIME_W;
     time_text->base.align_h = UI_ALIGN_RIGHT;
     time_text->base.rect.x = COL_TIME_RIGHT_OFFSET;
-    if (!add_child_or_fail(row, (ui_element *)time_text))
-    {
-        destroy_element((ui_element *)row);
-        return false;
-    }
+    add_child_or_fail(row, (ui_element *)time_text);
 
     ui_button *remove = ui_button_create(&(SDL_FRect){0.0F, 0.0F, COL_DELETE_W, COL_DELETE_H},
                                          page->color_ink, page->color_button_down, "DELETE",
                                          &page->color_ink, handle_delete_button_click, row_ctx);
     if (remove == NULL)
     {
-        destroy_element((ui_element *)row);
-        return false;
+        fail_fast("todo_page: failed to create delete button");
     }
     remove->base.align_h = UI_ALIGN_RIGHT;
     remove->base.rect.x = COL_DELETE_RIGHT_OFFSET;
-    if (!add_child_or_fail(row, (ui_element *)remove))
-    {
-        destroy_element((ui_element *)row);
-        return false;
-    }
-
-    if (!add_child_or_fail(page->rows_container, (ui_element *)row))
-    {
-        return false;
-    }
-
-    return true;
+    add_child_or_fail(row, (ui_element *)remove);
+    add_child_or_fail(page->rows_container, (ui_element *)row);
 }
 
 /*
  * Rebuild the entire task-row container from current model/filter state.
  */
-static bool rebuild_task_rows(todo_page *page)
+static void rebuild_task_rows(todo_page *page)
 {
     if (page == NULL || page->rows_container == NULL)
     {
-        return false;
+        fail_fast("todo_page: invalid state in rebuild_task_rows");
     }
-    if (!ensure_row_context_capacity(page))
-    {
-        return false;
-    }
+    ensure_row_context_capacity(page);
 
     // Rows are a projection of model state; rebuild from scratch after changes.
     ui_layout_container_clear_children(page->rows_container, true);
@@ -484,23 +441,20 @@ static bool rebuild_task_rows(todo_page *page)
             continue;
         }
 
-        if (!add_task_row(page, i))
-        {
-            return false;
-        }
+        add_task_row(page, i);
     }
 
-    return update_task_summary(page);
+    update_task_summary(page);
 }
 
 /*
  * Append one task model entry, growing storage as needed.
  */
-static bool append_task(todo_page *page, const char *title, const char *due_time, bool is_done)
+static void append_task(todo_page *page, const char *title, const char *due_time, bool is_done)
 {
     if (page == NULL || title == NULL || due_time == NULL)
     {
-        return false;
+        fail_fast("todo_page: invalid append_task input");
     }
 
     if (page->task_count == page->task_capacity)
@@ -509,7 +463,7 @@ static bool append_task(todo_page *page, const char *title, const char *due_time
         todo_task *new_tasks = realloc((void *)page->tasks, new_capacity * sizeof(todo_task));
         if (new_tasks == NULL)
         {
-            return false;
+            fail_fast("todo_page: failed to grow task storage");
         }
         page->tasks = new_tasks;
         page->task_capacity = new_capacity;
@@ -518,13 +472,13 @@ static bool append_task(todo_page *page, const char *title, const char *due_time
     char *task_title = duplicate_string(title);
     if (task_title == NULL)
     {
-        return false;
+        fail_fast("todo_page: failed to duplicate task title");
     }
 
     if (page->next_task_id == UINT64_MAX)
     {
         free(task_title);
-        return false;
+        fail_fast("todo_page: task id counter overflow");
     }
 
     todo_task *task = &page->tasks[page->task_count];
@@ -534,7 +488,6 @@ static bool append_task(todo_page *page, const char *title, const char *due_time
     SDL_snprintf(task->due_time, sizeof(task->due_time), "%s", due_time);
     task->is_done = is_done;
     page->task_count++;
-    return true;
 }
 
 /*
@@ -632,29 +585,26 @@ static void fill_random_time(char *buffer, size_t buffer_size)
 /*
  * Create a new task from the text input value and refresh rows.
  */
-static bool add_task_from_input(todo_page *page)
+static void add_task_from_input(todo_page *page)
 {
     if (page == NULL || page->task_input == NULL)
     {
-        return false;
+        fail_fast("todo_page: invalid state in add_task_from_input");
     }
 
     const char *input_value = ui_text_input_get_value(page->task_input);
     if (input_value == NULL || input_value[0] == '\0')
     {
-        return true;
+        return;
     }
 
     char due_time[6] = "00:00";
     fill_current_time(due_time, sizeof(due_time));
 
-    if (!append_task(page, input_value, due_time, false))
-    {
-        return false;
-    }
+    append_task(page, input_value, due_time, false);
 
     ui_text_input_clear(page->task_input);
-    return rebuild_task_rows(page);
+    rebuild_task_rows(page);
 }
 
 /*
@@ -728,13 +678,10 @@ static void handle_add_button_click(void *context)
     todo_page *page = (todo_page *)context;
     if (page == NULL)
     {
-        return;
+        fail_fast("todo_page: add callback context is invalid");
     }
 
-    if (!add_task_from_input(page))
-    {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to add task from input");
-    }
+    add_task_from_input(page);
 }
 
 /*
@@ -756,14 +703,11 @@ static void handle_filter_change(size_t selected_index, const char *selected_lab
     todo_page *page = (todo_page *)context;
     if (page == NULL)
     {
-        return;
+        fail_fast("todo_page: filter callback context is invalid");
     }
 
     page->selected_filter_index = selected_index;
-    if (!rebuild_task_rows(page))
-    {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to rebuild rows after filter change");
-    }
+    rebuild_task_rows(page);
 }
 
 /*
@@ -821,7 +765,7 @@ bool todo_page_resize(todo_page *page, int viewport_width, int viewport_height)
 {
     if (page == NULL)
     {
-        return false;
+        fail_fast("todo_page_resize called with NULL page");
     }
 
     page->viewport_width = viewport_width;
@@ -835,13 +779,13 @@ todo_page *todo_page_create(SDL_Window *window, ui_runtime *context, int viewpor
 {
     if (window == NULL || context == NULL)
     {
-        return NULL;
+        fail_fast("todo_page_create called with invalid arguments");
     }
 
     todo_page *page = calloc(1U, sizeof(todo_page));
     if (page == NULL)
     {
-        return NULL;
+        fail_fast("todo_page: failed to allocate page object");
     }
 
     page->context = context;
@@ -865,64 +809,121 @@ todo_page *todo_page_create(SDL_Window *window, ui_runtime *context, int viewpor
     page->header_left =
         ui_pane_create(&(SDL_FRect){LAYOUT_MARGIN, LAYOUT_MARGIN, 1.0F, HEADER_HEIGHT}, color_panel,
                        &page->color_ink);
+    if (page->header_left == NULL)
+    {
+        fail_fast("todo_page: failed to create header_left pane");
+    }
     page->header_right =
         ui_pane_create(&(SDL_FRect){LAYOUT_MARGIN, LAYOUT_MARGIN, HEADER_RIGHT_W, HEADER_HEIGHT},
                        color_panel, &page->color_ink);
+    if (page->header_right == NULL)
+    {
+        fail_fast("todo_page: failed to create header_right pane");
+    }
 
     page->title_text = ui_text_create(LAYOUT_MARGIN + 22.0F, LAYOUT_MARGIN + 28.0F,
                                       "TODO TASK MANAGEMENT SYSTEM V0.1", page->color_ink, NULL);
+    if (page->title_text == NULL)
+    {
+        fail_fast("todo_page: failed to create title text");
+    }
 
     char header_datetime[40];
     format_header_datetime(header_datetime, sizeof(header_datetime));
     page->datetime_text = ui_text_create(LAYOUT_MARGIN + 24.0F, LAYOUT_MARGIN + 28.0F,
                                          header_datetime, page->color_muted, NULL);
+    if (page->datetime_text == NULL)
+    {
+        fail_fast("todo_page: failed to create datetime text");
+    }
 
     page->icon_cell =
         ui_pane_create(&(SDL_FRect){LAYOUT_MARGIN, INPUT_ROW_Y, ICON_CELL_W, INPUT_ROW_HEIGHT},
                        color_panel, &page->color_ink);
+    if (page->icon_cell == NULL)
+    {
+        fail_fast("todo_page: failed to create icon cell pane");
+    }
     page->icon_arrow =
         ui_text_create(LAYOUT_MARGIN + 22.0F, INPUT_ROW_Y + 26.0F, ">", color_accent, NULL);
+    if (page->icon_arrow == NULL)
+    {
+        fail_fast("todo_page: failed to create icon arrow text");
+    }
 
     page->task_input = ui_text_input_create(
         &(SDL_FRect){input_field_x, INPUT_ROW_Y, INPUT_FIELD_W, INPUT_ROW_HEIGHT},
         page->color_muted, color_panel, page->color_ink, page->color_ink, "enter task...",
         page->color_muted, window, handle_task_input_submit, page);
+    if (page->task_input == NULL)
+    {
+        fail_fast("todo_page: failed to create task input");
+    }
 
     page->add_button = ui_button_create(
         &(SDL_FRect){LAYOUT_MARGIN, INPUT_ROW_Y, ADD_BUTTON_W, INPUT_ROW_HEIGHT}, color_button_dark,
         page->color_button_down, "ADD", &page->color_ink, handle_add_button_click, page);
+    if (page->add_button == NULL)
+    {
+        fail_fast("todo_page: failed to create add button");
+    }
 
     page->stats_text =
         ui_text_create(LAYOUT_MARGIN, STATS_ROW_Y, "0 ACTIVE - 0 DONE", page->color_ink, NULL);
+    if (page->stats_text == NULL)
+    {
+        fail_fast("todo_page: failed to create stats text");
+    }
 
     page->filter_group = ui_segment_group_create(
         &(SDL_FRect){LAYOUT_MARGIN, STATS_ROW_Y, FILTER_W, FILTER_H}, TODO_FILTER_LABELS,
         SDL_arraysize(TODO_FILTER_LABELS), 0U, color_panel, color_button_dark,
         page->color_button_down, page->color_muted, color_panel, &page->color_ink,
         handle_filter_change, page);
+    if (page->filter_group == NULL)
+    {
+        fail_fast("todo_page: failed to create filter group");
+    }
 
     page->top_rule = ui_hrule_create(1.0F, page->color_ink, 0.0F);
-    if (page->top_rule != NULL)
+    if (page->top_rule == NULL)
+    {
+        fail_fast("todo_page: failed to create top rule");
+    }
+    else
     {
         page->top_rule->base.rect = (SDL_FRect){LAYOUT_MARGIN, LIST_TOP_Y - 6.0F, 1.0F, 1.0F};
     }
 
     page->list_frame = ui_pane_create(&(SDL_FRect){LAYOUT_MARGIN, LIST_TOP_Y, 1.0F, 1.0F},
                                       color_panel, &page->color_ink);
+    if (page->list_frame == NULL)
+    {
+        fail_fast("todo_page: failed to create list frame");
+    }
 
     page->rows_container = ui_layout_container_create(
         &(SDL_FRect){LAYOUT_MARGIN, LIST_TOP_Y, 1.0F, 1.0F}, UI_LAYOUT_AXIS_VERTICAL, NULL);
-
-    if (page->rows_container != NULL)
+    if (page->rows_container == NULL)
     {
-        // Scroll view takes ownership of rows_container on success.
-        page->scroll_view =
-            ui_scroll_view_create(&(SDL_FRect){LAYOUT_MARGIN, LIST_TOP_Y, 1.0F, 1.0F},
-                                  (ui_element *)page->rows_container, SCROLL_STEP, NULL);
+        fail_fast("todo_page: failed to create rows container");
+    }
+
+    // Scroll view takes ownership of rows_container on success.
+    page->scroll_view =
+        ui_scroll_view_create(&(SDL_FRect){LAYOUT_MARGIN, LIST_TOP_Y, 1.0F, 1.0F},
+                              (ui_element *)page->rows_container, SCROLL_STEP, NULL);
+    if (page->scroll_view == NULL)
+    {
+        fail_fast("todo_page: failed to create scroll view");
     }
 
     page->bottom_rule = ui_hrule_create(1.0F, page->color_ink, 0.0F);
-    if (page->bottom_rule != NULL)
+    if (page->bottom_rule == NULL)
+    {
+        fail_fast("todo_page: failed to create bottom rule");
+    }
+    else
     {
         page->bottom_rule->base.rect = (SDL_FRect){LAYOUT_MARGIN, LIST_TOP_Y, 1.0F, 1.0F};
     }
@@ -930,89 +931,55 @@ todo_page *todo_page_create(SDL_Window *window, ui_runtime *context, int viewpor
     page->clear_done = ui_button_create(
         &(SDL_FRect){LAYOUT_MARGIN, LIST_TOP_Y, CLEAR_BUTTON_W, CLEAR_BUTTON_H}, color_button_dark,
         page->color_button_down, "CLEAR DONE", &page->color_ink, handle_clear_button_click, page);
+    if (page->clear_done == NULL)
+    {
+        fail_fast("todo_page: failed to create clear-done button");
+    }
 
     page->remaining_text =
         ui_text_create(LAYOUT_MARGIN, LIST_TOP_Y, "0 REMAINING", page->color_muted, NULL);
+    if (page->remaining_text == NULL)
+    {
+        fail_fast("todo_page: failed to create remaining text");
+    }
 
     page->fps_counter =
         ui_fps_counter_create(viewport_width, viewport_height, 12.0F, page->color_ink, NULL);
+    if (page->fps_counter == NULL)
+    {
+        fail_fast("todo_page: failed to create fps counter");
+    }
     page->window_root =
         ui_window_create(&(SDL_FRect){0.0F, 0.0F, (float)viewport_width, (float)viewport_height});
-    if (page->fps_counter != NULL && page->window_root != NULL)
+    if (page->window_root == NULL)
     {
-        page->fps_counter->base.parent = &page->window_root->base;
-        page->fps_counter->base.align_h = UI_ALIGN_RIGHT;
-        page->fps_counter->base.align_v = UI_ALIGN_BOTTOM;
+        fail_fast("todo_page: failed to create window root");
     }
-
-    if (page->header_left == NULL || page->header_right == NULL || page->title_text == NULL ||
-        page->datetime_text == NULL || page->icon_cell == NULL || page->icon_arrow == NULL ||
-        page->task_input == NULL || page->add_button == NULL || page->stats_text == NULL ||
-        page->filter_group == NULL || page->top_rule == NULL || page->list_frame == NULL ||
-        page->rows_container == NULL || page->scroll_view == NULL || page->bottom_rule == NULL ||
-        page->clear_done == NULL || page->remaining_text == NULL || page->fps_counter == NULL ||
-        page->window_root == NULL)
-    {
-        destroy_element((ui_element *)page->scroll_view);
-        if (page->scroll_view == NULL)
-        {
-            destroy_element((ui_element *)page->rows_container);
-        }
-        destroy_element((ui_element *)page->header_left);
-        destroy_element((ui_element *)page->header_right);
-        destroy_element((ui_element *)page->title_text);
-        destroy_element((ui_element *)page->datetime_text);
-        destroy_element((ui_element *)page->icon_cell);
-        destroy_element((ui_element *)page->icon_arrow);
-        destroy_element((ui_element *)page->task_input);
-        destroy_element((ui_element *)page->add_button);
-        destroy_element((ui_element *)page->stats_text);
-        destroy_element((ui_element *)page->filter_group);
-        destroy_element((ui_element *)page->top_rule);
-        destroy_element((ui_element *)page->list_frame);
-        destroy_element((ui_element *)page->bottom_rule);
-        destroy_element((ui_element *)page->clear_done);
-        destroy_element((ui_element *)page->remaining_text);
-        destroy_element((ui_element *)page->fps_counter);
-        destroy_element((ui_element *)page->window_root);
-        page->rows_container = NULL;
-        page->scroll_view = NULL;
-        page->task_input = NULL;
-        page->stats_text = NULL;
-        page->remaining_text = NULL;
-        page->datetime_text = NULL;
-        free(page);
-        return NULL;
-    }
+    page->fps_counter->base.parent = &page->window_root->base;
+    page->fps_counter->base.align_h = UI_ALIGN_RIGHT;
+    page->fps_counter->base.align_v = UI_ALIGN_BOTTOM;
 
     // Single source of truth for viewport-dependent geometry at startup.
     relayout_page(page);
 
-    if (!register_element(page, (ui_element *)page->header_left) ||
-        !register_element(page, (ui_element *)page->header_right) ||
-        !register_element(page, (ui_element *)page->title_text) ||
-        !register_element(page, (ui_element *)page->window_root) ||
-        !register_element(page, (ui_element *)page->title_text) ||
-        !register_element(page, (ui_element *)page->datetime_text) ||
-        !register_element(page, (ui_element *)page->icon_cell) ||
-        !register_element(page, (ui_element *)page->icon_arrow) ||
-        !register_element(page, (ui_element *)page->task_input) ||
-        !register_element(page, (ui_element *)page->add_button) ||
-        !register_element(page, (ui_element *)page->stats_text) ||
-        !register_element(page, (ui_element *)page->filter_group) ||
-        !register_element(page, (ui_element *)page->top_rule) ||
-        !register_element(page, (ui_element *)page->list_frame) ||
-        !register_element(page, (ui_element *)page->scroll_view) ||
-        !register_element(page, (ui_element *)page->bottom_rule) ||
-        !register_element(page, (ui_element *)page->clear_done) ||
-        !register_element(page, (ui_element *)page->remaining_text) ||
-        !register_element(page, (ui_element *)page->fps_counter))
-    {
-        destroy_task_storage(page);
-        unregister_elements(page);
-        free(page);
-        return NULL;
-    }
+    register_element(page, (ui_element *)page->header_left);
+    register_element(page, (ui_element *)page->header_right);
+    register_element(page, (ui_element *)page->window_root);
+    register_element(page, (ui_element *)page->title_text);
+    register_element(page, (ui_element *)page->datetime_text);
+    register_element(page, (ui_element *)page->icon_cell);
+    register_element(page, (ui_element *)page->icon_arrow);
+    register_element(page, (ui_element *)page->task_input);
+    register_element(page, (ui_element *)page->add_button);
+    register_element(page, (ui_element *)page->stats_text);
+    register_element(page, (ui_element *)page->filter_group);
+    register_element(page, (ui_element *)page->top_rule);
+    register_element(page, (ui_element *)page->list_frame);
+    register_element(page, (ui_element *)page->scroll_view);
+    register_element(page, (ui_element *)page->bottom_rule);
+    register_element(page, (ui_element *)page->clear_done);
+    register_element(page, (ui_element *)page->remaining_text);
+    register_element(page, (ui_element *)page->fps_counter);
 
     static const char *initial_task_titles[] = {
         "red", "orange", "yellow", "green", "blue", "indigo", "violet", "cyan", "magenta", "amber",
@@ -1022,22 +989,10 @@ todo_page *todo_page_create(SDL_Window *window, ui_runtime *context, int viewpor
     for (size_t i = 0U; i < SDL_arraysize(initial_task_titles); ++i)
     {
         fill_random_time(initial_due_time, sizeof(initial_due_time));
-        if (!append_task(page, initial_task_titles[i], initial_due_time, false))
-        {
-            destroy_task_storage(page);
-            unregister_elements(page);
-            free(page);
-            return NULL;
-        }
+        append_task(page, initial_task_titles[i], initial_due_time, false);
     }
 
-    if (!rebuild_task_rows(page))
-    {
-        destroy_task_storage(page);
-        unregister_elements(page);
-        free(page);
-        return NULL;
-    }
+    rebuild_task_rows(page);
 
     return page;
 }
@@ -1046,7 +1001,7 @@ bool todo_page_update(todo_page *page)
 {
     if (page == NULL)
     {
-        return false;
+        fail_fast("todo_page_update called with NULL page");
     }
 
     const time_t now = time(NULL);
@@ -1059,7 +1014,11 @@ bool todo_page_update(todo_page *page)
     page->last_header_time = now;
     char header_datetime[40];
     format_header_datetime(header_datetime, sizeof(header_datetime));
-    return ui_text_set_content(page->datetime_text, header_datetime);
+    if (!ui_text_set_content(page->datetime_text, header_datetime))
+    {
+        fail_fast("todo_page: failed to update header datetime text");
+    }
+    return true;
 }
 
 static void *create_todo_page_instance(SDL_Window *window, ui_runtime *context, int viewport_width,
@@ -1094,7 +1053,7 @@ void todo_page_destroy(todo_page *page)
 {
     if (page == NULL)
     {
-        return;
+        fail_fast("todo_page_destroy called with NULL page");
     }
 
     destroy_task_storage(page);

--- a/src/util/fail_fast.c
+++ b/src/util/fail_fast.c
@@ -1,0 +1,15 @@
+#include "util/fail_fast.h"
+
+#include <SDL3/SDL.h>
+
+#include <stdarg.h>
+#include <stdlib.h>
+
+_Noreturn void fail_fast(const char *format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    SDL_LogMessageV(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_CRITICAL, format, args);
+    va_end(args);
+    abort();
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor page lifecycle management to adopt a fail-fast approach for unrecoverable errors, introducing a `fail_fast` utility for standardized error logging and process termination.
> 
>   - **Behavior**:
>     - Refactor page lifecycle management to adopt a fail-fast approach for unrecoverable errors in `corners_page.c`, `showcase_page.c`, and `todo_page.c`.
>     - Introduce `fail_fast()` utility in `fail_fast.c` to log critical errors and abort the process.
>     - Update `main.c` to use `fail_fast()` for critical error handling during page selection and startup.
>   - **Functions**:
>     - Replace error handling with `fail_fast()` in `corners_page_create()`, `showcase_page_create()`, and `todo_page_create()`.
>     - Use `fail_fast()` in `register_element()`, `unregister_elements()`, and other critical functions across pages to ensure immediate termination on failure.
>   - **Documentation**:
>     - Update comments in `app_page.h`, `corners_page.h`, `showcase_page.h`, and `todo_page.h` to reflect fail-fast policy.
>     - Add `fail_fast.h` and `fail_fast.c` to document and implement the fail-fast utility.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=akurilin%2Fcui&utm_source=github&utm_medium=referral)<sup> for 495fa93a5a8548d2c2f3a0dd3ae62127dae2c62f. You can [customize](https://app.ellipsis.dev/akurilin/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->